### PR TITLE
Fix oldestOwner issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ function oldestBreakdown (metrics, convos) {
   var breakdown = {};
 
   var oldestTime = null;
-  var oldestOwner = null;
+  var oldestOwner = '';
 
   var active = convos.filter(function (convo) { return convo.status === 'active'; });
 


### PR DESCRIPTION
`oldestOwner` may remain null, which then causes the Metrics library to throw an error.
